### PR TITLE
bugfix in speed saturation

### DIFF
--- a/cnr_controller_interfaces/cnr_controller_interface/include/cnr_controller_interface/internal/cnr_joint_command_controller_interface_impl.h
+++ b/cnr_controller_interfaces/cnr_controller_interface/include/cnr_controller_interface/internal/cnr_joint_command_controller_interface_impl.h
@@ -230,9 +230,9 @@ inline bool JointCommandController<H,T>::exitUpdate()
                                this->m_sampling_period, m_max_velocity_multiplier, true, &report))
     {
       print_report = true;
+      m_target.q()  = m_last_target.q() + saturated_qd * this->m_dt.toSec();
+      m_target.qd() = saturated_qd;
     }
-    m_target.q()  = m_last_target.q() + saturated_qd * this->m_dt.toSec();
-    m_target.qd() = saturated_qd;
 
     m_last_target.copy(m_target, m_target.ONLY_JOINT);
 

--- a/cnr_hardware_interfaces/cnr_fake_hardware_interface/src/cnr_fake_hardware_interface/cnr_fake_robot_hw.cpp
+++ b/cnr_hardware_interfaces/cnr_fake_hardware_interface/src/cnr_fake_hardware_interface/cnr_fake_robot_hw.cpp
@@ -205,6 +205,9 @@ bool FakeRobotHW::doInit()
   registerInterface(&m_ft_jh);
 
   m_p_jh_active = m_v_jh_active = m_e_jh_active = false;
+
+  doRead(ros::Time::now(),ros::Duration(m_sampling_period));
+
   CNR_RETURN_TRUE(m_logger);
 }
 


### PR DESCRIPTION
Changes:

**cnr_joint_command_controller_interface_imp**:

target.q=last_target.q+saturated_qd *dt  only if the speed is saturated. This line can be improved because the velocity could vary during the period, considering the possibility to use acceleration. This introduces a small error, in the previous version the error accumulates over time

**cnr_fake_robot_hw**:
add a read to initialize position (it fixes the bug related to the non-zero initial position)


 
